### PR TITLE
Add ADB_INSTALL_TIMEOUT

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,7 @@
+machine:
+  environment:
+    ADB_INSTALL_TIMEOUT: 8
+
 test:
   override:
     # start the emulator


### PR DESCRIPTION
Builds are failing with following error. Ex. https://circleci.com/gh/startling/android-example/3

```
> Building 92%4% > :app:packageDebugTest:app:packageDebugTest
> Building 94%6% > :app:assembleDebugTest:app:assembleDebugTest
> Building 96%8% > :app:connectedAndroidTest:app:connectedAndroidTest
> Building 98% > :app:connectedAndroidTest02:00:32 E/Device: Error during shell execution: null
> Building 98% > :app:connectedAndroidTestUnable to install /home/ubuntu/android-example/app/build/outputs/apk/app-debug.apk
```

I added ADB_INSTALL_TIMEOUT via web UI and passed. https://circleci.com/gh/startling/android-example/4

